### PR TITLE
Fix the URL of party

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -266,7 +266,7 @@
                 <p>開始時間: 17:30<br>開催場所:<br class="u-sp-b">大阪市中央区本町1-7-1 三星本町ビルB1<br>参加費: 3000円（会場払い）</p>
               </div>
               <div class="btn left u-pc-b">
-                <a href="https://rubykansai.doorkeeper.jp/events/59706" target="_blank" class="basic">懇親会に参加する</a>
+                <a href="https://rubykansai.doorkeeper.jp/events/59707" target="_blank" class="basic">懇親会に参加する</a>
               </div><!-- /.btn -->
             </div>
             <div class="imgbox">
@@ -274,7 +274,7 @@
             </div><!-- /.img -->
           </div>
           <div class="btn u-sp-b">
-            <a href="https://rubykansai.doorkeeper.jp/events/59706" target="_blank" class="basic">懇親会に参加する</a>
+            <a href="https://rubykansai.doorkeeper.jp/events/59707" target="_blank" class="basic">懇親会に参加する</a>
           </div><!-- /.btn -->
         </div>
       </section>


### PR DESCRIPTION
懇親会への申込みページのURLが、本編への申込みページのURLになっていたようなので差し替えてみました。

今週末の関西Ruby会議2017楽しみにしてます。
